### PR TITLE
Fixes configuration order bug

### DIFF
--- a/Helpers/Initializer.php
+++ b/Helpers/Initializer.php
@@ -61,7 +61,7 @@ class Initializer
 	 */
 	public static function config($configName = 'main', $mergeWith = null)
 	{
-		$files = array($configName);
+		$files = array();
 		$directory = Config::value('yiinitializr.app.directories.config.' . $configName);
 		if (null === $directory)
 			throw new \Exception("Unable to find 'yiinitializr.app.directories.config.'{$configName} on the settings.");
@@ -79,6 +79,7 @@ class Initializer
 
 		// do we have any other configuration files to merge with?
 		$mergedSettingFiles = Config::value('yiinitializr.app.files.config.' . $configName);
+    $files[] = $configName;
 		if (null !== $mergedSettingFiles)
 		{
 			if (is_array($mergedSettingFiles))


### PR DESCRIPTION
I think the changes introduced in SHA: 9c29a7e40d3081b2766bdf6685ec1b0c1466735c commit are completely correct.

I was working on my project and noticed the configuration files are in wrong order, which leads to incomplete configuration and overwritten configurations if they are not in `env` or `local` files (the common takes precedence but it should be the other way around).

For example by default the order of files will be:

```
array(6) {
  [0]=>
  string(7) "backend"
  [1]=>
  string(97) "D:\Workshop\Localhost\projects\yiinitializr-intermediate\backend\www/../../common/config/main.php"
  [2]=>
  string(96) "D:\Workshop\Localhost\projects\yiinitializr-intermediate\backend\www/../../common/config/env.php"
  [3]=>
  string(98) "D:\Workshop\Localhost\projects\yiinitializr-intermediate\backend\www/../../common/config/local.php"
  [4]=>
  string(3) "env"
  [5]=>
  string(5) "local"
}
```

then the configuration for let's say aliases will be:

```
["aliases"]=>
  array(6) {
    ["bootstrap"]=>
    string(24) "vendor.yii-twbs.yiistrap"
    ["yiiwheels"]=>
    string(24) "vendor.2amigos.yiiwheels"
    ["frontend"]=>
    string(85) "D:\Workshop\Localhost\projects\yiinitializr-intermediate\common\config/../../frontend"
    ["common"]=>
    string(83) "D:\Workshop\Localhost\projects\yiinitializr-intermediate\common\config/../../common"
    ["backend"]=>
    string(84) "D:\Workshop\Localhost\projects\yiinitializr-intermediate\common\config/../../backend"
    ["vendor"]=>
    string(17) "common.lib.vendor"
  }
```

and because we don't have a vendor alias (it comes after it's used), if we try to call the `bootstrap` component, for example by adding this in a view:

```
<?php $form = $this->beginWidget( 'bootstrap.widgets.TbActiveForm', array( 'id' => 'loginForm' ) ); ?>
```

It will give an error with the message: `Alias "bootstrap.widgets.TbActiveForm" is invalid.
 Make sure it points to an existing PHP file and the file is readable.`

---

If we add the main configuration file after common configuration files are added (as the correct order should be: common configuration, common configuration environment, application configuration, application configuration environment), the configuration are loaded in correct order and config file is merged like it's supposed to be.

```
array(6) {
  [0]=>
  string(97) "D:\Workshop\Localhost\projects\yiinitializr-intermediate\backend\www/../../common/config/main.php"
  [1]=>
  string(96) "D:\Workshop\Localhost\projects\yiinitializr-intermediate\backend\www/../../common/config/env.php"
  [2]=>
  string(98) "D:\Workshop\Localhost\projects\yiinitializr-intermediate\backend\www/../../common/config/local.php"
  [3]=>
  string(7) "backend"
  [4]=>
  string(3) "env"
  [5]=>
  string(5) "local"
}

["aliases"]=>
  array(6) {
    ["frontend"]=>
    string(85) "D:\Workshop\Localhost\projects\yiinitializr-intermediate\common\config/../../frontend"
    ["common"]=>
    string(83) "D:\Workshop\Localhost\projects\yiinitializr-intermediate\common\config/../../common"
    ["backend"]=>
    string(84) "D:\Workshop\Localhost\projects\yiinitializr-intermediate\common\config/../../backend"
    ["vendor"]=>
    string(17) "common.lib.vendor"
    ["bootstrap"]=>
    string(24) "vendor.yii-twbs.yiistrap"
    ["yiiwheels"]=>
    string(24) "vendor.2amigos.yiiwheels"
  }
```
