### PR TITLE
Aliases fix

### DIFF
--- a/Helpers/Initializer.php
+++ b/Helpers/Initializer.php
@@ -41,7 +41,8 @@ class Initializer
 		if (php_sapi_name() !== 'cli') // aren't we in console?
 		{
 			$app = \Yii::createWebApplication($config); // create web
-			$app->setAliases($config['aliases']);
+			if(isset($config['aliases']) && !empty($config['aliases']))
+				$app->setAliases($config['aliases']);
 		}
 		else
 		{


### PR DESCRIPTION
This is possible fix for #5.
I've manualy added a second call of `setAliases` after Yii::createWebApplication.
This will recheck all aliases again and assign for missing values.
With this - the order of the given aliases will not be important.

After this PR, you can set back to the previous state your Yiinitializr templates
(like https://github.com/tonydspaniard/yiinitializr-basic/commit/fb86522ec832b5f8ffd666bb7c23f1c7d1d3f988) 
