### PR TITLE
error_reporting fixed

### DIFF
--- a/Helpers/Initializer.php
+++ b/Helpers/Initializer.php
@@ -140,7 +140,8 @@ class Initializer
 		defined('YII_ENABLE_EXCEPTION_HANDLER') or define('YII_ENABLE_EXCEPTION_HANDLER', YII_ENABLE_ERROR_HANDLER);
 
 		// php config
-		error_reporting(-1);
+		if(isset($params['php.error_reporting']))
+			error_reporting($params['php.error_reporting']);
 		if(isset($params['php.defaultCharset']))
 			ini_set('default_charset', $params['php.defaultCharset']);
 		if(isset($params['php.timezone']))


### PR DESCRIPTION
Now we can write 'params' => array( 'php.error_reporting' => ... ) ) to override error reporting level. Before this change error_reporting was set to -1

Hi, amigo! :) Small fix for your great library!
